### PR TITLE
CRONAPP-2465 [Câmara] Desabilitação por recurso de segurança no menu …

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -621,7 +621,7 @@
                 $element.hide();
               }
               if (!enabled) {
-                $element.find('*').addBack().attr('disabled', true);
+                $element.find('*').addBack().attr('disabled', true).off('click').on('click', e => e.preventDefault());
               }
             };
 


### PR DESCRIPTION
[Problema]
Desabilitação por recurso de segurança no menu dinâmico, não funcionava para menu

[Solução]
Alem de desabilitar o item, tem que remover o hook do click, para que não seja possível disparar o click.