### PR TITLE
CRONAPP-274 QRcode não está ficando no tamanho informado no ambiente …

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -662,7 +662,10 @@
               return ngModel.$modelValue || "";
             };
             var getSize = function(){
-              return scope.size || $(element).outerWidth();
+              let outerWidth = $(element).outerWidth();
+              let outerHeight = $(element).outerHeight();
+              let bestFit = outerWidth < outerHeight ? outerWidth : outerHeight;
+              return scope.size || bestFit;
             };
             var isNUMBER = function(text){
               var ALLOWEDCHARS = /^[0-9]*$/;


### PR DESCRIPTION
**Problema**
O qr code, deve ter todos os lados iguais
Então quando se fazia o redimensionamento e não respeitava essas proporções, ele simplesmente assumia todos os lados iguais a partir do width, que gerava problema de enquadramento na div.

**Solução**
Fiz um ajuste para que ele se adeque a div onde ele está inserido, mantendo todos os lados iguais.