### PR TITLE
CRONAPP-1873 Não era possível voltar ao valor zero no componente aval…

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -4410,7 +4410,9 @@
               clonned.attr("idx", i);
               clonned.click(function() {
                 scope.$apply(function() {
-                  ngModelCtrl.$viewValue = parseInt($(this).attr("idx")); //set new view value
+                  let idx = parseInt($(this).attr("idx"));
+                  //set new view value or reset the value
+                  ngModelCtrl.$viewValue = ( ngModelCtrl.$viewValue !== idx ) ? idx : 0;
                   ngModelCtrl.$commitViewValue();
 
                 }.bind(this));


### PR DESCRIPTION
**Problema:** Não é possível voltar ao valor zero no componente avaliação
**Solução:** Eu mudei a diretiva para identificar quando for o mesmo valor clicado e setar o valor 0.