### PR TITLE
CRONAPP-2218 Tooltip ativado mesmo quando está configurado como vazio…

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -2397,8 +2397,6 @@
                 var tooltip = '';
                 if (column.tooltip && column.tooltip.length)
                   tooltip = column.tooltip;
-                else if (column.label && column.label.length)
-                  tooltip = column.label;
 
                 if (tooltip)  {
                   var classForTooltip = app.common.generateId();


### PR DESCRIPTION
**Problema:**
Tooltip ativado mesmo quando está configurado como vazio numa grade

**Solução:** 
Removido atribuição do label ao tooltip quando o parâmetro de tooltip não houver valor.