### PR TITLE
CRONAPP-2654 Mensagem de erro ao errar credenciais não é apresentada

### DIFF
--- a/js/controllers.authentication.js
+++ b/js/controllers.authentication.js
@@ -147,6 +147,9 @@
         error = message.exception
       } else if (typeof data === 'string' && status !== 502) {
         error = data;
+        if (!error && status === 401) {
+          error = $translate.instant('Login.view.invalidPassword');
+        }
       } else {
         error = $translate.instant('Admin.server.out');
       }


### PR DESCRIPTION
**Problema:**
Mensagem de erro ao errar credenciais não é apresentada

**Solução:**
Só não é exibida na autenticação normal, retorna apenas o status 401, verificado quando o status é 401 e tratado