### PR TITLE
CRONAPP-1104 Erros de upload de arquivo em CRUD

### DIFF
--- a/js/app.authentication.js
+++ b/js/app.authentication.js
@@ -199,10 +199,14 @@ var app = (function() {
             prefix: 'i18n/locale_',
             suffix: '.json'
           },
-            {
-              prefix: 'node_modules/cronapp-framework-js/i18n/locale_',
-              suffix: '.json'
-            }]
+          {
+            prefix: 'node_modules/cronapp-framework-js/i18n/locale_',
+            suffix: '.json'
+          },
+          {
+            prefix: 'node_modules/cronapi-js/i18n/locale_',
+            suffix: '.json'
+          }]
         });
 
         $translateProvider

--- a/js/directives.js
+++ b/js/directives.js
@@ -407,7 +407,7 @@
             var templateDyn    = '\
                                 <div ng-show="!$ngModel$" ngf-drop="" ngf-drag-over-class="dragover">\
                                   <input id="$id$" aria-label="$userHtml$" ng-if="!$ngModel$" autocomplete="off" tabindex="-1" class="uiSelectRequired ui-select-offscreen" style="top: inherit !important;margin-left: 85px !important;margin-top: 50px !important; display: none;" type=text ng-model="$ngModel$" $required$>\
-                                  <button id="$idbutton$" class="btn" ngf-drop="" ngf-select="" ngf-change="cronapi.internal.uploadFile(\'$ngModel$\', $file, \'uploadprogress$number$\', $fileInfo$)" ngf-max-size="$maxFileSize$">\
+                                  <button id="$idbutton$" class="btn" ngf-drop="" ngf-select="" ngf-change="cronapi.internal.uploadFile(\'$ngModel$\', $file, \'uploadprogress$number$\', $fileInfo$, $invalidFiles)" ngf-max-size="$maxFileSize$">\
                                     $userHtml$\
                                   </button>\
                                   <div class="progress" data-type="bootstrapProgress" id="uploadprogress$number$" style="display:none">\


### PR DESCRIPTION
**Problema:**
Não exibindo a mensagem de erro, quando arquivo era maior que o permitido

**Solução:**
Ajuste na directive.js para enviar o erro e app.authentication.js para carregar os translates do cronapi