### PR TITLE
CRONAPP-1816 - Agendador apresenta data no padrão DD/MM em alguns locais e em outros MM/DD

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -1489,6 +1489,7 @@
 
 
           let cronSchedulerProperties = {
+            dateHeaderTemplate: kendo.template(`#=kendo.toString(date, ${kendo.culture().name.toLowerCase().includes('pt')?'\'ddd dd/M\'':'\'ddd M/dd\''})#`),
             showWorkHours: options.showWorkHours,
             selectable: true,
             date: schedulerStartDate,


### PR DESCRIPTION
CRONAPP-1816

Agendador apresenta data no padrão DD/MM em alguns locais e em outros MM/DD

Solução:

Adicionado template para o cabeçalho das views do agendador baseado no kendo.culture()