### PR TITLE
CRONAPP-2139 Criar loading de relatório

### DIFF
--- a/css/themes/custom/material/custom-material.css
+++ b/css/themes/custom/material/custom-material.css
@@ -786,7 +786,6 @@ textarea.form-control.k-textbox {
     position: fixed;
     z-index: 2000;
     top: 0;
-    right: 100%;
     width: 100%;
     height: 4px;
 }

--- a/js/reports/reports.service.js
+++ b/js/reports/reports.service.js
@@ -359,7 +359,7 @@
       Pace.options.minTime = 1750;
       Pace.options.maxProgressPerFrame = 1;
       Pace.options.ghostTime = 120000;
-      Pace.restart();
+      let refreshPaceUntilLoad = setInterval( () => Pace.restart(), 2500);
 
       scriptsStimulsoft.forEach(function(url, idx) {
         this.loadScript(url, function(success) {
@@ -367,6 +367,7 @@
           if (!success)
             loadedAllSuccess = false;
           if (totalAdded == total) {
+            clearInterval(refreshPaceUntilLoad);
             Pace.options.initialRate = 0.03;
             Pace.options.minTime = 250;
             Pace.options.maxProgressPerFrame = 20;


### PR DESCRIPTION
**Problema:**
Não estava exibindo o PACE em nenhuma pagina do sistema.

**Solução**
Corrigir o css do PACE e exibir o pace até o relatório ser carregado (recarregando a barra, para não dar a impressão que está travado), pois o mesmo adiciona JS via dom no HTML e o PACE não consegue identificar e fazer o tracker.