### PR TITLE
CRONAPP-2860 Não é possível selecionar imagem svg no componente imagem

### DIFF
--- a/components/crn-image.components.json
+++ b/components/crn-image.components.json
@@ -10,7 +10,7 @@
     "src": {
       "removable": false,
       "type": "projectResource",
-      "resourceType": "image/jpeg,image/gif,image/png",
+      "resourceType": "image/jpeg,image/gif,image/png,image/svg+xml",
       "mandatory": true
     },
     "ng-init": {


### PR DESCRIPTION
**Problema:**
IDE não seleciona imagens SVG

**Solução:**
Parametrizado no crn-image o mime type da busca do svg