### PR TITLE
CRONAPP-2926 Caixa de seleção dinâmica não mostra dados presentes na …

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -3822,6 +3822,7 @@
 
             if (combobox.dataSource.transport && combobox.dataSource.transport.options) {
               combobox.dataSource.transport.options.combobox = combobox;
+              combobox.dataSource.transport.options.grid = combobox;
               combobox.dataSource.transport.options.$compile = $compile;
               combobox.dataSource.transport.options.scope = scope;
               combobox.dataSource.transport.options.ngModelCtrl = ngModelCtrl;
@@ -5664,6 +5665,9 @@ app.kendoHelper = {
       return;
     }
 
+    if (!this.options.kendoCallback)
+      this.options.kendoCallback = e;
+
     var isFirst;
     if (this.options.combobox && this.options.combobox.options.readData) {
       e.success(this.options.combobox.options.readData);
@@ -5690,6 +5694,11 @@ app.kendoHelper = {
       } else {
         e.success([]);
       }
+    }
+
+    if (this.options.fromRead) {
+      this.options.kendoCallback.success(cronappDatasource.data);
+      doFetch = false;
     }
 
     if (doFetch) {


### PR DESCRIPTION
**Problema:**
Datasource do combobox não funcionava caso o datasource do cronapp já estivesse aberto e não preenchia o combo.

**Solução:**
Passar a verificar notificação fromRead e chamar o callback do datasource do combobox