### PR TITLE
CRONAPP-2973 Campo da grade com máscara apresenta erro na edição em l…

### DIFF
--- a/postupdate.json
+++ b/postupdate.json
@@ -90,6 +90,11 @@
       "file": "index.html",
       "script": "node_modules/pace/themes/pace-theme-minimal.css",
       "type": "style"
+    },
+    {
+      "file": "index.html",
+      "script": "node_modules/cronapp-framework-js/dist/components/js/jquery.inputmask.bundle.js",
+      "type": "script"
     }
   ],
   "removes": [
@@ -236,11 +241,6 @@
     {
       "file": "index.html",
       "script": "plugins/angular-translate/angular-translate.min.js",
-      "type": "script"
-    },
-    {
-      "file": "index.html",
-      "script": "plugins/cronapp-framework-js/dist/components/js/jquery.inputmask.bundle.js",
       "type": "script"
     },
     {
@@ -492,7 +492,7 @@
       "new": "node_modules/cronapp-framework-js/dist/components/js/jquery.mask.min.js"
     },
     {
-      "old": "plugins/cronapp-framework-js/dist/components/js/jquery.mask.min.js",
+      "old": "plugins/cronapp-framework-js/dist/components/js/jquery.inputmask.bundle.js",
       "new": "node_modules/cronapp-framework-js/dist/components/js/jquery.inputmask.bundle.js"
     },
     {


### PR DESCRIPTION
**Problema:**
O plugin jquery.inputmask.bundle.js tinha sido removido do index do projeto

**Solução:**
Corrigido a remoção indevida do plugin, ajustado o rename errado do jquery.mask.min.js para o jquery.inputmask.bundle.js e colocado para adicionar esse plugin nos projetos que foram removidos.