### PR TITLE
CRONAPP-3154  [Câmara] Ao selecionar um item na caixa de seleção, outro item é selecionado

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -3594,11 +3594,11 @@
             options.dataBound = attrs.ngDataBound ? function (){scope.$eval(attrs.ngDataBound)}: undefined;
             options.filtering = attrs.ngFiltering ? function (){scope.$eval(attrs.ngFiltering)}: undefined;
             options.open = function(e) {
-              if (!dataSourceScreen.fetched) {
+              if (!dataSourceScreen.fetched || (dataSourceScreen.data.length > combobox.dataSource.data().length)) {
                 combobox.options.firstLazyRead = true;
                 combobox.dataSource.read();
               }
-            }
+            };
 
             options.select = attrs.ngSelect ? function (){scope.$eval(attrs.ngSelect);}: undefined;
 
@@ -3822,7 +3822,6 @@
 
             if (combobox.dataSource.transport && combobox.dataSource.transport.options) {
               combobox.dataSource.transport.options.combobox = combobox;
-              combobox.dataSource.transport.options.grid = combobox;
               combobox.dataSource.transport.options.$compile = $compile;
               combobox.dataSource.transport.options.scope = scope;
               combobox.dataSource.transport.options.ngModelCtrl = ngModelCtrl;


### PR DESCRIPTION
**Problema:**
Datasource do combobox não consegue trabalhar corretamente quando é chamado o .read() (vindo do eventos push do datasource do cronapp)

**Solução:**
Removido o combobox do options.grid, para não ser chamado pelo datasource do cronapp e verificado caso o datasource (cronapp) já esteja aberto e tenha mais dados que o datasource do combo, mandar o ds do combo ler.