### PR TITLE
CRONAPP-3198 Checkbox deixa de funcionar após atualização

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -4618,8 +4618,8 @@
           link: function (scope, el, attrs, ctrl) {
             ctrl.$formatters = [];
             ctrl.$parsers = [];
-            let falseValue = attrs.ngFalseValue ? attrs.ngFalseValue.split("'").join("") : undefined;
-            let trueValue = attrs.ngTrueValue ? attrs.ngTrueValue.split("'").join("") : undefined;
+            let falseValue = attrs.ngFalseValue ? attrs.ngFalseValue.split("'").join("") : "false";
+            let trueValue = attrs.ngTrueValue ? attrs.ngTrueValue.split("'").join("") : "true";
 
             if (attrs.crnAllowNullValues == 'true') {
               ctrl.$render = function () {


### PR DESCRIPTION
**Problema:**
Quando não informado o valor para true / false o checkbox não marcava/desmarcava

**Solução:**
Se não houver valor setado, o padrão será true/false