### PR TITLE
CRONAPP-3415 Campo data se comportando como um campo tipo texto

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "raphael": "DmitryBaranovskiy/raphael#v2.1.4",
     "ui-select-infinity": "hyzhak/ui-select-infinity#v0.1.5",
     "angular-ui-router": "angular-ui/ui-router#0.2.15",
-    "eonasdan-bootstrap-datetimepicker": "Eonasdan/bootstrap-datetimepicker#4.17.37",
+    "eonasdan-bootstrap-datetimepicker": "Eonasdan/bootstrap-datetimepicker#4.17.49",
     "natives": "1.1.6",
     "angular": "1.5.9",
     "angular-ui-bootstrap": "0.13.0",


### PR DESCRIPTION
Problema:
  Foi feita a atualização do jquery para versão 3.5.1, o componente bootstrap-datetimepicker é incompativel
Solução:
  Atualizar a versão