### PR TITLE
CRONAPP-3307 - Caixa de Seleção Multipla não atualiza Fonte

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -4003,12 +4003,18 @@
             options['close'] = attrs.ngClose ? function (){_scope.$eval(attrs.ngClose)}: undefined;
             options['dataBound'] = attrs.ngDatabound ? function (){_scope.$eval(attrs.ngDatabound)}: undefined;
             options['filtering'] = attrs.ngFiltering ? function (){_scope.$eval(attrs.ngFiltering)}: undefined;
-            options['open'] = attrs.ngOpen ? function (){_scope.$eval(attrs.ngOpen)}: undefined;
             options['cascade'] = attrs.ngCascade ? function (){_scope.$eval(attrs.ngCascade)}: undefined;
             evtSelect = attrs.ngSelect ? function (){_scope.$eval(attrs.ngSelect)}: undefined;
             deselect = attrs.ngDeselect ? function (){_scope.$eval(attrs.ngDeselect)}: undefined;
 
             var combobox = $element.kendoMultiSelect(options).data('kendoMultiSelect');
+
+            combobox.bind("open", (e) => {
+              combobox.dataSource.data(options.dataSource.transport.options.cronappDatasource.data);
+              if (attrs.ngOpen) {
+                _scope.$eval(attrs.ngOpen);
+              }
+            });
             combobox.enable(true);
 
             $("[aria-describedby='" + `${attrs.id}_taglist` + "']").attr('id', `${attrs.id}-container`);

--- a/js/directives.js
+++ b/js/directives.js
@@ -4010,7 +4010,9 @@
             var combobox = $element.kendoMultiSelect(options).data('kendoMultiSelect');
 
             combobox.bind("open", (e) => {
-              combobox.dataSource.data(options.dataSource.transport.options.cronappDatasource.data);
+              if (combobox.dataSource) {
+                combobox.dataSource.data(options.dataSource.transport.options.cronappDatasource.data);
+              }
               if (attrs.ngOpen) {
                 _scope.$eval(attrs.ngOpen);
               }


### PR DESCRIPTION
https://cronapp.atlassian.net/browse/CRONAPP-3307

## Problema:
Após inserir um registro e solicitar atualização da fonte de dados pelo servidor, o item adicionado não é exibido no componente da caixa de seleção multipla.
## Solução:
Inserido em options a opção de checar os dados da fonte de dados que popula o componente da caixa de seleção multipla.