### PR TITLE
CRONAPP-3350 Atualizar a release para 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cronapp-framework-js",
-  "version": "2.7.2",
+  "version": "2.9.0",
   "description": "Javascript library for CronApp's projects",
   "main": "cronapp.framework.js",
   "scripts": {


### PR DESCRIPTION
Solução:
Atualização do npm para 2.9.0 (sem publicação no npm)