### PR TITLE
CRONAPP-4000 - Refatorar Job de build do framework-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Javascript library for CronApp's projects",
   "main": "cronapp.framework.js",
   "scripts": {
+    "build": "npm i && gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Problema:
Hoje o job é executando da seguinte maneira:

npm install
npm install --global gulp-cli
gulp

Solução:

npm run build