### PR TITLE
CRONAPP-4019 - Menu dinâmico fica invisível na IDE

### DIFF
--- a/components/templates/cron-dynamic-menu.designtime.html
+++ b/components/templates/cron-dynamic-menu.designtime.html
@@ -1,6 +1,7 @@
-<ul class="nav navbar-nav" style="float:left">
-  <li ng-if="attrs.options.subMenuOptions" ng-repeat="menu in attrs.options.subMenuOptions" class="dropdown component-holder"> 
-    <a href="javascript:void(0);" class="dropdown-toggle" style="color: #fff;min-width: 123px;" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> 
-    <span>{{menu.name}}</span> <span class="caret"></span> </a> 
-  </li> 
+<ul class="nav navbar-nav ng-scope" style="float:left">
+  <li ng-if="attrs.options.subMenuOptions" ng-repeat="menu in attrs.options.subMenuOptions"
+    class="dropdown crn-menu-item">
+    <a class="dropdown-toggle" data-toggle="dropdown">
+      <span>{{menu.name}}</span> <span class="caret"></span> </a>
+  </li>
 </ul>


### PR DESCRIPTION
**Problema**
Os itens do menu dinâmico sempre ficava com a cor branca no designtime 

**Solução**
remoção do style que aplicava a cor branca e redução de excesso de código.