### PR TITLE
CRONAPP-3982- support2.8-Lista de opções - Revisão de componentes

### DIFF
--- a/components/crn-radioOption.components.json
+++ b/components/crn-radioOption.components.json
@@ -3,6 +3,24 @@
   "pallete": false,
   "text_pt_BR": "Item de opção",
   "text_en_US": "Radio Item",
+  "properties": {
+    "checked": {
+      "removable": false,
+      "displayName_pt_BR": "Selecionado",
+      "displayName_en_US": "selected",
+      "type": "list",
+      "options": [
+        {
+          "key": "true",
+          "value_pt_BR": "Sim",
+          "value_en_US": "Yes"
+        }
+      ],
+      "selector": "input[ng-checked]",
+      "childrenProperty": true,
+      "order": 2
+    }
+  },
   "childrenProperties": [
     {
       "name": "value",
@@ -15,18 +33,10 @@
     {
       "name": "content",
       "selector": "label",
-      "displayName_pt_BR": "Conteúdo",
-      "displayName_en_US": "Content",
+      "displayName_pt_BR": "Legenda",
+      "displayName_en_US": "Subtitle",
       "type": "content",
       "order": 2
-    },
-    {
-      "name": "ng-checked",
-      "selector": "input[ng-checked]",
-      "displayName_pt_BR": "Checked",
-      "displayName_en_US": "Checked",
-      "type": "content",
-      "order": 3
     },
     {
       "name": "ng-click",

--- a/components/templates/radiogroup.template.html
+++ b/components/templates/radiogroup.template.html
@@ -1,4 +1,4 @@
-<div class="" ng-model="vars.radio${RANDOM}">
+<div class="crn-radiogroup" ng-model="vars.radio${RANDOM}">
     <div class = "k-content" data-component="crn-radioOption">
         <input class = "k-radio" type="radio" crn-value=""  value="1" name="optionsRadios" id="optionsRadios1${COMPONENTID}" ng-checked="">
         <label class="k-radio-label" for="optionsRadios1${COMPONENTID}">Option One</label>

--- a/css/app.css
+++ b/css/app.css
@@ -258,3 +258,7 @@ a {
     display: flex;
     align-items: center;
 }
+
+.crn-radiogroup .k-content{
+    background-color: transparent;
+}


### PR DESCRIPTION
**Problema**
Componentes não estão totalmente low-code.

**Solução**
Revisar os componentes ajustando o arquivo components.json, e se necessário, ajustar arquivos relacionados.

- Padronização da organização do arquivo
- Verificação do styles e childrenProperties

**Componente corrigido:**
- Lista de opção (crn-radiogroup)