### PR TITLE
CRONAPP-3984-Tabela Simples - Revisão de componentes

### DIFF
--- a/components/crn-table.components.json
+++ b/components/crn-table.components.json
@@ -16,14 +16,24 @@
   },
   "styles": [
     {
-      "selector": "div#{id} th.active",
-      "text_pt_BR": "Coluna Ativa",
-      "text_en_US": "Active Column"
+      "selector": "div#{id} th",
+      "text_pt_BR": "Cabeçalho da tabela",
+      "text_en_US": "Table header"
     },
     {
-      "selector": "div#{id} th",
-      "text_pt_BR": "Coluna Padrão",
-      "text_en_US": "Default Column"
+      "selector": "div#{id} tbody tr:nth-child(2n+1)",
+      "text_pt_BR": "Linha ímpar",
+      "text_en_US": "Ood line"
+    },
+    {
+      "selector": "div#{id} tbody tr:nth-child(2n)",
+      "text_pt_BR": "Linha par",
+      "text_en_US": "Even line"
+    },
+    {
+      "selector": "div#{id} tbody tr:hover",
+      "text_pt_BR": "Linha Hover",
+      "text_en_US": "Hover Line"
     }
   ],
   "childrenProperties": [


### PR DESCRIPTION
**Problema**
Componentes não estão totalmente low-code.

**Solução**
Revisar os componentes ajustando o arquivo components.json, e se necessário, ajustar arquivos relacionados.

- Padronização da organização do arquivo
- Verificação do styles e childrenProperties

**Componente corrigido:**
- Tabela Simples (crn-table)