### PR TITLE
CRONAPP-3980-Ícone- Revisão de componentes

### DIFF
--- a/components/crn-icon.components.json
+++ b/components/crn-icon.components.json
@@ -37,6 +37,13 @@
       "order": 2
     }
   },
+  "styles": [
+    {
+      "selector": "div#{id} i",
+      "text_pt_BR": "Ícone",
+      "text_en_US": "Icon"
+    }
+  ],
   "childrenProperties": [
     {
       "name": "class",


### PR DESCRIPTION
**Problema**
Componentes não estão totalmente low-code.

**Solução**
Revisar os componentes ajustando o arquivo components.json, e se necessário, ajustar arquivos relacionados.

- Padronização da organização do arquivo
- Verificação do styles e childrenProperties

**Componente corrigido:**
- Icon (crn-icon)