### PR TITLE
CRONAPP-4038 - Ajuste do componente Área de texto

### DIFF
--- a/components/crn-textarea.components.json
+++ b/components/crn-textarea.components.json
@@ -50,7 +50,7 @@
       "name": "resize",
       "selector": "textarea",
       "displayName_pt_BR": "Redimensionável",
-      "displayName_en_US": "Number of Lines",
+      "displayName_en_US": "Resize",
       "type": "text",
       "order": 5
     },


### PR DESCRIPTION
**Problema**
Tradução de resize no componente área de texto estava errado.

**Solução**
Ajustado a tradução.