### PR TITLE
CRONAPP-4205 - Melhorar ícones do dashboard na IDE

### DIFF
--- a/components/crn-cron-dashboard-viewer.components.json
+++ b/components/crn-cron-dashboard-viewer.components.json
@@ -5,7 +5,12 @@
   "text_pt_BR": "Visualizador de dashboard",
   "text_en_US": "Dashboard viewer",
   "order": 2,
-  "class": "adjust-icon mdi mdi-view-dashboard",
+  "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-cron-dashboard-viewer.svg",
+  "description": "Estrutura para criar painel com gráficos",
+  "description_en_US": "Structure for creating dashboard with graphics",
+  "category": [
+      "COMBOS"
+  ],
   "designTimeSelector": "cron-dashboard-viewer",
   "templateURL": "src/main/webapp/node_modules/cronapp-framework-js/dist/components/templates/cron-dashboard-viewer.template.html",
   "designTimeDynamic": true,

--- a/img/cron-icon/crn-cron-dashboard-viewer.svg
+++ b/img/cron-icon/crn-cron-dashboard-viewer.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Camada_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#C9C9C9;}
+</style>
+<path class="st0" d="M20,0H4C1.8,0,0,1.8,0,4v16c0,2.2,1.8,4,4,4h16c2.2,0,4-1.8,4-4V4C24,1.8,22.2,0,20,0z M12,19c0,0.5-0.5,1-1,1
+	H5c-0.5,0-1-0.5-1-1v-8c0-0.5,0.5-1,1-1h6c0.5,0,1,0.5,1,1V19z M20,19c0,0.5-0.5,1-1,1h-4c-0.5,0-1-0.5-1-1v-2c0-0.5,0.5-1,1-1h4
+	c0.5,0,1,0.5,1,1V19z M20,13c0,0.5-0.5,1-1,1h-4c-0.5,0-1-0.5-1-1v-2c0-0.5,0.5-1,1-1h4c0.5,0,1,0.5,1,1V13z M20,7c0,0.5-0.5,1-1,1
+	H5C4.5,8,4,7.5,4,7V5c0-0.5,0.5-1,1-1h14c0.5,0,1,0.5,1,1V7z"/>
+<g id="Camada_3">
+</g>
+<g id="Camada_4">
+</g>
+<g id="Camada_2_1_">
+</g>
+</svg>


### PR DESCRIPTION
**Solução da melhoria**
O componente Visualizador de Dashboard não possuia um ícone svg, categoria e descrição conforme a nova versão da IDE solicitava.