### PR TITLE
CRONAPP-4426 - Ajustar propriedades do componente imagem dinâmica

### DIFF
--- a/components/crn-dynamic-image.components.json
+++ b/components/crn-dynamic-image.components.json
@@ -27,13 +27,13 @@
     },
     {
       "selector": "div#{id} .dynamic-image-container",
-      "text_pt_BR": "Botão",
-      "text_en_US": "Button"
+      "text_pt_BR": "Campo pontilhado",
+      "text_en_US": "Dotted field"      
     },
     {
       "selector": "div#{id} .btn",
-      "text_pt_BR": "Campo pontilhado",
-      "text_en_US": "Dotted field"
+      "text_pt_BR": "Botão",
+      "text_en_US": "Button"
     }    
   ],
   "childrenProperties": [


### PR DESCRIPTION
**Melhoria:**
Ajustado os estilos do componente Imagem dinâmica em que os nomes dos estilos campo pontinhado e botão estavam trocados.