### PR TITLE
CRONAPP-4284 - Imagem dinâmica não se adequa ao layout do tema fuse

### DIFF
--- a/css/themes/custom/fuse/custom-fuse.min.css
+++ b/css/themes/custom/fuse/custom-fuse.min.css
@@ -2578,11 +2578,7 @@ i.component-holder.fa.fa-star {
 
 .dynamic-image-container {
     border: 2px dashed;
-    text-align: center;
-    height: 75px;
-    justify-content: center;
-    align-items: center;
-    display: flex;
+    padding: 20px;
 }
 
 .dynamic-image-container button.btn {


### PR DESCRIPTION
**Problema:**
Ao utilizar o componente imagem dinâmica, a imagem ultrapassa os limites do componente.

**Solução:**
Ajuste no css para não limitar o tamanho do componente, logo ele se adapta ao tamanho da imagem.