### PR TITLE
CRONAPP-4634 - Voltar propriedades dos componentes Data e Data e hora

### DIFF
--- a/components/crn-datepicker.components.json
+++ b/components/crn-datepicker.components.json
@@ -40,6 +40,21 @@
       "selector": "input",
       "type": "type",
       "order": 2
+    },    
+    {
+      "name": "placeholder",
+      "selector": "input",
+      "type": "text"
+    },
+    {
+      "name": "mask",
+      "selector": "input",
+      "type": "mask"
+    },
+    {
+      "name": "mask-placeholder",
+      "selector": "input",
+      "type": "text"
     },
     {
       "name": "ng-required",

--- a/components/crn-datetimepicker.components.json
+++ b/components/crn-datetimepicker.components.json
@@ -39,6 +39,21 @@
       "mandatory": true
     },
     {
+      "name": "placeholder",
+      "selector": "input",
+      "type": "text"
+    },
+    {
+      "name": "mask",
+      "selector": "input",
+      "type": "mask"
+    },
+    {
+      "name": "mask-placeholder",
+      "selector": "input",
+      "type": "text"
+    },
+    {
       "name": "ng-init",
       "selector": "input",
       "type": "event"


### PR DESCRIPTION
**Melhoria:**
Voltar as propriedades como estavam na documentação dos componentes Data e Data e hora.