### PR TITLE
CRONAPP-3678 - Trocar nomenclatura usada para a propriedade crn-datasource

### DIFF
--- a/components/crn-table.components.json
+++ b/components/crn-table.components.json
@@ -50,8 +50,6 @@
     {
       "name": "crn-datasource",
       "selector": "div[crn-datasource]",
-      "displayName_pt_BR": "Configurações",
-      "displayName_en_US": "Configuration",
       "global": true,
       "type": "pageDatasource"
     },


### PR DESCRIPTION
**Solução:**
Removido displayName fixo e mantido o padrão para crn-daasource.