### PR TITLE
CRONAPP-4723 - Barra de navegação não abre editor de menu ao clicar no menu dinâmico

### DIFF
--- a/components/crn-dynamic-menu.components.json
+++ b/components/crn-dynamic-menu.components.json
@@ -11,10 +11,10 @@
     "LAYOUTS"
   ],
   "order": 11,
-  "wrapper": false,
+  "wrapper": true,
   "designTimeDynamic": true,
   "designTimeHTMLURL": "src/main/webapp/node_modules/cronapp-framework-js/dist/components/templates/cron-dynamic-menu.designtime.html",
-  "designTimeSelector": ":self",
+  "designTimeSelector": "cron-dynamic-menu",
   "templateURL": "src/main/webapp/node_modules/cronapp-framework-js/dist/components/templates/cron-dynamic-menu.template.html",
   "properties": {
     "class": {


### PR DESCRIPTION
**Solução:**
Ajustado componente menu dinâmico para funcionar o duplo clique para abrir o modal do rap.