### PR TITLE
CRONAPP-4776 - Área de Assinatura aplica zoom na assinatura quando a …

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -4996,12 +4996,11 @@
                         var data = $scope.ngModel;
     
                         if (value !== old) {
-    
+                            signaturePad.clear();
                             signature.fromDataURL("data:image/png;base64," + value, {
                                 ratio: 1
                             });
                             $scope.ngModel = value;
-                            signature.clear();
                         }
                     }, true);
     


### PR DESCRIPTION
…página tem zoom

**Solução**
Limpar o componente antes do fromDataUrl pois o zoom era aplicado 2 ou + vezes.