### PR TITLE
CRONAPP-4090 - Estilização do título da caixa de seleção dinâmica não altera cores no editor html

### DIFF
--- a/components/templates/cron-dynamic-combobox.template.html
+++ b/components/templates/cron-dynamic-combobox.template.html
@@ -1,5 +1,5 @@
 <div class="form-group" id="cron-${COMPONENTID}">
-    <label for="cron-${COMPONENTID}">Label</label>
+    <label for="cron-${COMPONENTID}" id="cron-${COMPONENTID}_label">Label</label>
     <cron-dynamic-select options="{}" ng-required="false" id="cron-${COMPONENTID}" ng-model="vars.dynCombobox${RANDOM}" class="k-textbox crn-select form-control" style="">
     </cron-dynamic-select>
 </div> 


### PR DESCRIPTION
**Solução:**
Adicionado id no label para que o designtime identifique a estilização do css