### PR TITLE
CRONAPP-4315 - A faixa do cookies não fica fixa no rodapé do sit

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('minify-js', function() {
 });
 
 gulp.task('minify-css', function() {
-  return gulp.src(['css/app.css', 'css/cronos-bootstrap.css', 'css/cronos-template.css', 'css/cronos.css', 'css/signup.css'])
+  return gulp.src(['css/**/*'])
     .pipe(uglifycss())
     .pipe(gulp.dest('dist/css/'));
 });


### PR DESCRIPTION
Solução
Corrigido gulpfile que apenas minificava arquivos css fixos.