### PR TITLE
CRONAPP-2184 - Visualizador de relatório toma toda a tela do smartphone

### DIFF
--- a/js/reports/reports.service.js
+++ b/js/reports/reports.service.js
@@ -156,6 +156,9 @@
         }
         var viewer = new Stimulsoft.Viewer.StiViewer(options, viewerId, false);
         viewer.report = report;
+        if(StiJsViewer.prototype.IsTouchDevice()) {
+          viewer.options.appearance.interfaceType = Stimulsoft.Viewer.StiInterfaceType.Touch;
+        }
         return viewer;
       };
     


### PR DESCRIPTION
Solução
Verificação se o dispositivo possui recurso de touch e habilitar a interface Touch. https://www.stimulsoft.com/en/documentation/online/programming-manual/index.html?reports_js_web_viewer_settings.htm