### PR TITLE
CRONAPP-4804 - Alteração no nome dos componentes Colunas

### DIFF
--- a/components/crn-eight-four-container.components.json
+++ b/components/crn-eight-four-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-eight-four-container",
-    "text_pt_BR": "8/4 Colunas",
-    "text_en_US": "8/4 Columns",
+    "text_pt_BR": "2 Colunas (8/4)",
+    "text_en_US": "2 Columns (8/4)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-eight-four-container.svg",
     "description": "Três recipiente ao lado para inserir componentes",
     "description_en_US": "Three container on the side for inserting components",

--- a/components/crn-four-eight-container.components.json
+++ b/components/crn-four-eight-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-four-eight-container",
-    "text_pt_BR": "4/8 Colunas",
-    "text_en_US": "4/8 Columns",
+    "text_pt_BR": "2 Colunas (4/8)",
+    "text_en_US": "2 Columns (4/8)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-four-eight-container.svg",
     "description": "Três recipiente ao lado para inserir componentes",
     "description_en_US": "Three container on the side for inserting components",

--- a/components/crn-one-container.components.json
+++ b/components/crn-one-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-one-container",
-    "text_pt_BR": "1 Coluna",
-    "text_en_US": "1 Column",
+    "text_pt_BR": "1 Coluna (12)",
+    "text_en_US": "1 Column (12)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-one-container.svg",
     "description": "Um recipiente para inserir componentes",
     "description_en_US": "A container for inserting components",

--- a/components/crn-three-container.components.json
+++ b/components/crn-three-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-three-container",
-    "text_pt_BR": "3 Colunas",
-    "text_en_US": "3 Columns",
+    "text_pt_BR": "3 Colunas (4/4/4)",
+    "text_en_US": "3 Columns (4/4/4)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-three-container.svg",
     "description": "Três recipiente ao lado para inserir componentes",
     "description_en_US": "Three container on the side for inserting components",

--- a/components/crn-trhee-six-three-container.components.json
+++ b/components/crn-trhee-six-three-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-three-six-three-container",
-    "text_pt_BR": "3/6/3 Colunas",
-    "text_en_US": "3/6/3 Columns",
+    "text_pt_BR": "3 Colunas (3/6/3)",
+    "text_en_US": "3 Columns (3/6/3)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-three-six-three-container.svg",
     "description": "Três recipiente ao lado para inserir componentes",
     "description_en_US": "Three container on the side for inserting components",

--- a/components/crn-two-container.components.json
+++ b/components/crn-two-container.components.json
@@ -1,7 +1,7 @@
 {
     "name": "crn-two-container",
-    "text_pt_BR": "2 Colunas",
-    "text_en_US": "2 Columns",
+    "text_pt_BR": "2 Colunas (6/6)",
+    "text_en_US": "2 Columns (6/6)",
     "image": "/node_modules/cronapp-framework-js/img/cron-icon/crn-two-container.svg",
     "description": "Dois recipiente ao lado para inserir componentes",
     "description_en_US": "Two container on the side for inserting components",


### PR DESCRIPTION
**Melhoria:**
Ajustado os nomes dos seguintes componentes:
1 Coluna -> 1 Coluna (12)
2 Colunas -> 2 Colunas (6/6)
3 Colunas -> 3 Colunas (4/4/4)
3/6/3 Colunas -> 3 Colunas (3/6/3)
4/8 Colunas -> 2 Colunas (4/8)
8/4 Colunas -> 2 Colunas (8/4)