### PR TITLE
CRONAPP-5114 - Breadcrumb não funciona em produção (2.8.33)

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -4741,7 +4741,7 @@
                   let idMenu = attrs.idMenu;
 
                   // Capturar o  json do menu
-                  let menuOptions = $(`#${idMenu}`)[0].children[0].attributes['options'];
+                  let menuOptions = $(`#${idMenu}`)[0].parentElement.attributes['options'];
                   menuOptions = JSON.parse(menuOptions.value);
                   let subMenuOptions = menuOptions.subMenuOptions;
 


### PR DESCRIPTION
**Solução**
Atualizado o caminho para ter acesso ao json do option do menu dinamico