### PR TITLE
CRONAPP-5431 Erro na dependência entre as caixas de seleção a partir …

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -3586,6 +3586,9 @@
                           _combobox.isEvaluating = false;
                         } else {
                           _dataSource.findObj([options.value], false, function(data) {
+                            if (Array.isArray(data)) {
+                              data = data[0];
+                            }
                             options.success(data);
                             _combobox.isEvaluating = false;
 
@@ -3695,9 +3698,16 @@
                     var found = _goTo(_scope, combobox, combobox.dataItem());
 
                     if (!found) {
-                      dataItem = objectClone(combobox.dataItem(), combobox.dataSource.options.schema.model.fields);
-                      dataSourceScreen.data.push(dataItem);
-                      _goTo(_scope, combobox, dataItem);
+                      dataSourceScreen.findObj([value], false, (dataresult) => {
+                        if (Array.isArray(dataresult)) {
+                          dataresult = dataresult[0];
+                        }
+                        if (dataresult) {
+                          dataSourceScreen.data.push(dataresult);
+                          _goTo(_scope, combobox, dataresult);
+                          modelSetter(_scope, value);
+                        }
+                      });
                     }
                   }
                 }


### PR DESCRIPTION
…do filtro

Solução: O retorno do findObj vem um array, feito o ajuste para obter o valor filtrado corretamente e quando não existir no datasource corrente, efetuar uma busca e não pegar o dataItem do combo, que será vazio.