### PR TITLE
CRONAPP-5158 Visualizador de dashboard não apresenta opção para abrir

### DIFF
--- a/js/dashboard/dashboard.service.js
+++ b/js/dashboard/dashboard.service.js
@@ -79,10 +79,12 @@
 
       var context = $('#dashboardViewContext');
       if(!context.get(0)) {
-        body.append('<div id="dashboardViewContext"></div>');
+        var htmlViewer = $('<div id="dashboardViewContext" ng-include="\'node_modules/cronapp-framework-js/components/dashboard/dashboard.view.html\'"></div>');
+        $(body).append(htmlViewer);
+        $compile(htmlViewer)(scope);
         context = $('#dashboardViewContext');
       }
-      
+
       var h = parseInt($(window).height());
       var heightRepo = (h - 200) + "px";
       var viewerId = "StiViewer" + app.common.generateId();


### PR DESCRIPTION
**Problema**
Projetos que não tinham a DIV de renderização não abriam via bloco

**Solução**
Adicionar a DIV dashboardContextView à página em tempo de execução